### PR TITLE
feat: manifest version value bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ Unless you have an `action.yml` present in your root folder, this module is not 
 
 If you have an `action.yml` present, our config will attempt to adjust the container version to the newly pushed `npm` and `docker` tags.
 
+### Manifest.json
+
+Unless you have a `manifest.json` present in your root folder, this module is not added to the release config.
+
+If you have a `manifest.json` present, our config will attempt to adjust the `version` value to the newly pushed `npm` and `docker` tags.
+
 ### Docker
 
 Unless you have a `Dockerfile` present in your root folder, this module is not added to the release config. 

--- a/release.config.js
+++ b/release.config.js
@@ -140,6 +140,26 @@ if (actionExists) {
   });
 }
 
+const manifestExists = existsSync("./manifest.json");
+if (manifestExists) {
+  addPlugin("@google/semantic-release-replace-plugin", {
+    "replacements": [{
+      "files": [
+        "manifest.json"
+      ],
+      "from": `"version": ".*"`,
+      "to": `"version": "\${nextRelease.version}"`,
+      "results": [{
+        "file": "manifest.json",
+        "hasChanged": true,
+        "numMatches": 1,
+        "numReplacements": 1
+      }],
+      "countMatches": true
+    }]
+  });
+}
+
 addPlugin("@semantic-release/git", {
   "assets": [
     "LICENSE*",
@@ -151,7 +171,8 @@ addPlugin("@semantic-release/git", {
     "pnpm-lock.yaml",
     "public/**/*",
     "supabase/**/*",
-    "action.yml"
+    "action.yml",
+    "manifest.json"
   ],
   "message": `chore(<%= nextRelease.type %>): release <%= nextRelease.version %> <%= nextRelease.channel !== null ? \`on \${nextRelease.channel} channel \` : '' %>[skip ci]\n\n<%= nextRelease.notes %>`
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR adds support for `manifest.json` file. If present, the `version` value in the file will be updated to the newly pushed `npm` and `docker` tags. The release config has been updated to include `manifest.json` in the assets for `@semantic-release/git` plugin. The changes have been reflected in the `README.md` file.

_Generated using [OpenSauced](https://opensauced.ai/)._

A demo of the manifest version bump can be found here: https://github.com/Anush008/release/commit/7cc810292c0cdf56e6a32970c6506ecdec9be875.

## Related Tickets & Documents
Resolves https://github.com/open-sauced/ai/issues/53.

## Mobile & Desktop Screenshots/Recordings


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed