### PR TITLE
fix: Bump manifest only on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you have an `action.yml` present, our config will attempt to adjust the conta
 
 Unless you have a `manifest.json` present in your root folder, this module is not added to the release config.
 
-If you have a `manifest.json` present, our config will attempt to adjust the `version` value to the newly pushed `npm` and `docker` tags.
+If you have a `manifest.json` present, our config will attempt to adjust the `version` value to the newly pushed `npm` and `docker` tags. This version bump is limited to releases made exclusively on the `main` branch.
 
 ### Docker
 

--- a/release.config.js
+++ b/release.config.js
@@ -34,6 +34,7 @@ const noteKeywords = [
 const {
   GITHUB_SHA,
   GITHUB_REPOSITORY,
+  GITHUB_REF,
   GIT_COMMITTER_NAME,
   GIT_COMMITTER_EMAIL,
   GIT_AUTHOR_NAME,
@@ -141,7 +142,7 @@ if (actionExists) {
 }
 
 const manifestExists = existsSync("./manifest.json");
-if (manifestExists) {
+if (manifestExists && GITHUB_REF === "refs/heads/main") {
   addPlugin("@google/semantic-release-replace-plugin", {
     "replacements": [{
       "files": [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes the issue mentioned in https://github.com/open-sauced/ai/issues/121, by bumping the `manifest.json` version number only on main with integer-only version numbers.

Demo manifest bump on main: https://github.com/Anush008/release/commit/30987238314226570233c2b423773d26fc605e33

No manifest bump on beta: https://github.com/Anush008/release/commit/eb6a98cc10434d8d00969cfd6c0917137b204e67

## Related Tickets & Documents
Merging this will contribute to resolving https://github.com/open-sauced/ai/issues/121.

## Mobile & Desktop Screenshots/Recordings


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

